### PR TITLE
Expose ritual text and tags for kit steps

### DIFF
--- a/golden_pipeline/kit_assembler.py
+++ b/golden_pipeline/kit_assembler.py
@@ -91,6 +91,23 @@ def _load_jsonl(path: Path) -> List[Dict[str, Any]]:
                 raise ValueError(f"Invalid JSON in {path} line {ln}: {e}")
     return out
 
+def _collect_unique_strings(*sources: Any) -> List[str]:
+    """Normalize and merge string iterables while preserving insertion order."""
+
+    merged: List[str] = []
+    for src in sources:
+        if not src:
+            continue
+        iterable = [src] if isinstance(src, str) else src
+        for item in iterable:
+            if not isinstance(item, str):
+                continue
+            normalized = item.strip()
+            if not normalized or normalized in merged:
+                continue
+            merged.append(normalized)
+    return merged
+
 def assemble_kits(config: Dict[str, Any]) -> None:
     artifacts_dir = Path(config.get('artifacts_dir', 'artifacts'))
     phase3_dir = artifacts_dir / 'phase3'
@@ -180,16 +197,29 @@ def assemble_kits(config: Dict[str, Any]) -> None:
                 continue
 
             # RAW kit with embedded minimal step info (traceability & schema stability)
-            raw_steps_min = [
-                {
-                    'ritual_step_id': s.get('ritual_step_id') or s.get('id'),
+            kit_tags = _collect_unique_strings(kit.get('tags'), keywords)
+
+            raw_steps_min = []
+            for idx, s in enumerate(ordered_steps, 1):
+                ritual_step_id = s.get('ritual_step_id') or s.get('id')
+                step_keywords = _collect_unique_strings(s.get('tags'), s.get('keywords'))
+                if not step_keywords:
+                    step_keywords = list(kit_tags)
+                matched_text = s.get('matched_text')
+                if not isinstance(matched_text, str):
+                    matched_text = ''
+                raw_steps_min.append({
+                    'step_id': f"{kit_id}_{idx:05d}",
+                    'ritual_step_id': ritual_step_id,
                     'action': s.get('action'),
+                    'matched_text': matched_text,
+                    'text': matched_text,
+                    'keywords': step_keywords,
                     'source_doc_id': s.get('source_doc_id'),
                     'source_chunk_id': s.get('source_chunk_id'),
                     'char_start': s.get('char_start'),
                     'char_end': s.get('char_end')
-                } for s in ordered_steps
-            ]
+                })
 
             lean_steps, collapse_entries = _collapse_steps(ordered_steps)
             # Annotate collapse entries with kit id for derivations file
@@ -204,6 +234,7 @@ def assemble_kits(config: Dict[str, Any]) -> None:
                 'domain': domain,
                 'source_doc_ids': source_doc_ids,
                 'keywords': keywords,
+                'tags': kit_tags,
                 'description': description,
                 'step_ids': step_ids,
                 'steps': raw_steps_min,
@@ -243,3 +274,4 @@ if __name__ == '__main__':
     with open(cfg_path, 'r', encoding='utf-8') as f:
         cfg = yaml.safe_load(f)
     assemble_kits(cfg)
+

--- a/ritual_player/search_exporter.py
+++ b/ritual_player/search_exporter.py
@@ -12,6 +12,21 @@ artifacts/phase5/ui_search.minisearch.json with fields:
 Deterministic order; no stemming; simple tokenization left to MiniSearch.
 """
 import argparse, json, pathlib
+from typing import Iterable, Set
+
+
+def _merge_tags(*sources: Iterable[str]) -> Set[str]:
+    tags: Set[str] = set()
+    for src in sources:
+        if not src:
+            continue
+        iterable = [src] if isinstance(src, str) else src
+        for item in iterable:
+            if isinstance(item, str):
+                normalized = item.strip()
+                if normalized:
+                    tags.add(normalized)
+    return tags
 
 
 def main():
@@ -33,18 +48,27 @@ def main():
                 row = json.loads(s)
                 if row.get("kind") != "kit":
                     continue
+                kit_tags = _merge_tags(row.get("tags"), row.get("keywords"))
                 text_blobs = [row.get("title", ""), row.get("subtitle", "")]
+                if kit_tags:
+                    text_blobs.extend(sorted(kit_tags))
+                aggregated_tags = set(kit_tags)
                 for st in row.get("steps", []):
-                    text_blobs.append(st.get("text", ""))
+                    step_text = st.get("text") or st.get("matched_text") or ""
+                    text_blobs.append(step_text)
                     for m in st.get("materials", []) or []:
                         text_blobs.append(m)
                     if st.get("notes"):
                         text_blobs.append(st["notes"])
+                    step_tags = _merge_tags(st.get("tags"), st.get("keywords"))
+                    if step_tags:
+                        aggregated_tags.update(step_tags)
+                        text_blobs.extend(sorted(step_tags))
                 fulltext = " \n".join([t for t in text_blobs if t])
                 docs.append({
                     "id": row["kit_id"],
                     "title": row.get("title", row["kit_id"]),
-                    "tags": row.get("tags", []),
+                    "tags": sorted(aggregated_tags),
                     "n_steps": row.get("n_steps", 0),
                     "text": fulltext,
                 })

--- a/ritual_player/ui_data_generator.py
+++ b/ritual_player/ui_data_generator.py
@@ -10,7 +10,7 @@ Determinism: explicit sorting and LF newlines; no randomness or clocks.
 """
 from __future__ import annotations
 import argparse, json, os, pathlib, hashlib
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Iterable
 
 
 def sha256_bytes(b: bytes) -> str:
@@ -31,6 +31,20 @@ def write_jsonl(p: pathlib.Path, rows: List[Dict[str, Any]]):
     with p.open("w", encoding="utf-8", newline="\n") as f:
         for r in rows:
             f.write(json.dumps(r, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def _collect_tags(*sources: Iterable[Any]) -> List[str]:
+    tags = set()
+    for src in sources:
+        if not src:
+            continue
+        iterable = [src] if isinstance(src, str) else src
+        for item in iterable:
+            if isinstance(item, str):
+                normalized = item.strip()
+                if normalized:
+                    tags.add(normalized)
+    return sorted(tags)
 
 
 def main():
@@ -68,7 +82,7 @@ def main():
     for kit in sorted(kits, key=lambda k: k.get("kit_id", "")):
         kit_id = kit["kit_id"]
         title = kit.get("title") or kit.get("name") or kit_id
-        tags = sorted(set(kit.get("tags", [])))
+        tags = _collect_tags(kit.get("tags"), kit.get("keywords"))
         source_docs = sorted(set(kit.get("source_doc_ids", [])))
 
         # preserve original step ordering from kit; synthesize order if missing
@@ -76,16 +90,22 @@ def main():
         ui_steps = []
         for idx, s in enumerate(steps):
             media_refs = s.get("media_refs", [])
+            ritual_step_id = s.get("ritual_step_id")
+            step_id = s.get("step_id") or ritual_step_id or f"{kit_id}_{idx:05d}"
+            step_tags = _collect_tags(s.get("tags"), s.get("keywords"))
+            text_value = s.get("text") or s.get("matched_text") or ""
 
             ui_steps.append({
-                "step_id": s.get("step_id"),
+                "step_id": step_id,
+                "ritual_step_id": ritual_step_id,
                 "order": int(s.get("order", idx)),
-                "text": (s.get("text", "") or "").strip(),
+                "text": text_value.strip(),
                 "materials": s.get("materials", []),
                 "notes": s.get("notes", ""),
                 "overlay": s.get("overlay", {}),  # optional UI hints
                 "duration_s": int(s.get("duration_s", 0)),  # 0 if unknown
                 "media_refs": media_refs,
+                "tags": step_tags,
             })
 
         ui_row = {

--- a/tests/test_phase5_metadata_enrichment.py
+++ b/tests/test_phase5_metadata_enrichment.py
@@ -1,0 +1,96 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def read_jsonl(path: Path):
+    rows = []
+    if not path.exists():
+        return rows
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            data = line.strip()
+            if data:
+                rows.append(json.loads(data))
+    return rows
+
+
+def test_ui_generator_and_search_exporter_enrich_metadata(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    artifacts = tmp_path / "artifacts"
+    kits_dir = artifacts / "phase4" / "kits"
+    kits_dir.mkdir(parents=True)
+
+    kit_payload = {
+        "id": "demo-kit",
+        "name": "Demo Kit",
+        "keywords": ["banishing", "light"],
+        "tags": ["banishing", "light"],
+        "source_doc_ids": ["doc_aaaaaaaaaaaa"],
+        "step_ids": ["rit_step1", "rit_step2"],
+        "steps": [
+            {
+                "step_id": "demo-kit_00001",
+                "ritual_step_id": "rit_step1",
+                "matched_text": "Perform the cross",
+                "keywords": ["cross"],
+                "source_doc_id": "doc_aaaaaaaaaaaa",
+                "source_chunk_id": "doc_aaaaaaaaaaaa_00001",
+                "char_start": 0,
+                "char_end": 18,
+            },
+            {
+                "ritual_step_id": "rit_step2",
+                "matched_text": "Invoke the light",
+                "keywords": ["banishing", "light"],
+                "source_doc_id": "doc_aaaaaaaaaaaa",
+                "source_chunk_id": "doc_aaaaaaaaaaaa_00002",
+                "char_start": 19,
+                "char_end": 35,
+            },
+        ],
+    }
+    (kits_dir / "demo-kit.kit.json").write_text(json.dumps(kit_payload), encoding="utf-8")
+
+    py = sys.executable
+    subprocess.run(
+        [py, "ritual_player/ui_data_generator.py", "--artifacts", str(artifacts)],
+        check=True,
+        cwd=repo_root,
+    )
+
+    catalog_rows = read_jsonl(artifacts / "phase5" / "ui_catalog.jsonl")
+    assert len(catalog_rows) == 1
+    catalog_row = catalog_rows[0]
+
+    assert catalog_row["kit_id"] == "demo-kit"
+    assert catalog_row["tags"] == ["banishing", "light"]
+    assert catalog_row["n_steps"] == 2
+
+    step_one, step_two = catalog_row["steps"]
+    assert step_one["text"] == "Perform the cross"
+    assert step_one["tags"] == ["cross"]
+    assert step_one["step_id"] == "demo-kit_00001"
+    assert step_one["ritual_step_id"] == "rit_step1"
+
+    assert step_two["text"] == "Invoke the light"
+    assert step_two["tags"] == ["banishing", "light"]
+    assert step_two["step_id"] == "rit_step2"
+    assert step_two["ritual_step_id"] == "rit_step2"
+
+    subprocess.run(
+        [py, "ritual_player/search_exporter.py", "--artifacts", str(artifacts)],
+        check=True,
+        cwd=repo_root,
+    )
+
+    search_bundle_path = artifacts / "phase5" / "ui_search.minisearch.json"
+    bundle = json.loads(search_bundle_path.read_text(encoding="utf-8"))
+    assert bundle["docs"], "search exporter should emit docs"
+    doc = bundle["docs"][0]
+    assert doc["id"] == "demo-kit"
+    assert doc["tags"] == ["banishing", "cross", "light"]
+    assert doc["n_steps"] == 2
+    assert "Perform the cross" in doc["text"]
+    assert "Invoke the light" in doc["text"]


### PR DESCRIPTION
## Summary
- include matched text, deterministic step identifiers, and keyword/tag metadata in phase 4 kit serialization
- update the ritual player UI data generator to surface the new step text, identifiers, and tags while remaining backward compatible
- expand the search exporter to index enriched ritual text and aggregated tags, and cover the workflow with a regression test

## Testing
- pytest tests/test_phase5_metadata_enrichment.py
- pytest *(fails: ModuleNotFoundError: No module named 'onyx_scribe')*


------
https://chatgpt.com/codex/tasks/task_e_68cc8e741da4832d93463f7b425eda09